### PR TITLE
[Melodic] replaced deprecated pluginlib export macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
-sudo: required 
-dist: trusty 
 language: generic
+services:
+  - docker
+
 notifications:
   email:
     on_success: change
     on_failure: always
 env:
   global:
-    - ROS_DISTRO="indigo"
-    - UPSTREAM_WORKSPACE=file
-    - ROSINSTALL_FILENAME=.travis.rosinstall
+    - ROS_REPO=ros
   matrix:
-    - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
+    - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
+    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: .ci_config/travis.sh
-#  - source ./travis.sh  # Enable this when you have a package-local script 
+script:
+  - .ci_config/travis.sh
+#  - ./travis.sh  # Enable this when you have a package-local script

--- a/src/ipa_pointcloud_to_laserscan_nodelet.cpp
+++ b/src/ipa_pointcloud_to_laserscan_nodelet.cpp
@@ -132,7 +132,7 @@ void IpaPointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2Cons
   // does not do anything if the problem dies not occur -> leave for compatibility
   std::string cloud_frame_id = cloud_msg->header.frame_id;
   if(cloud_frame_id.find_first_of("/") == 0)
-  { 
+  {
     cloud_frame_id.erase(0,1);
   }
 
@@ -205,15 +205,15 @@ void IpaPointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2Cons
   NODELET_DEBUG_STREAM("Transform and publisch for scan took " << dur.toSec());
 }
 
-/** 
- * Function to project the pointcloud points within specified region to 
+/**
+ * Function to project the pointcloud points within specified region to
  * the laser scan frame and fill out the laserscan message with the relevant ranges
  * from the projection.
- * Theborders for the point selection is transformed into pointcloud frame in order 
+ * Theborders for the point selection is transformed into pointcloud frame in order
  * save time by avoiding unnessecairy point transformations
  */
-void IpaPointCloudToLaserScanNodelet::convert_pointcloud_to_laserscan(const sensor_msgs::PointCloud2ConstPtr &cloud, 
-                                                                      sensor_msgs::LaserScan &output, 
+void IpaPointCloudToLaserScanNodelet::convert_pointcloud_to_laserscan(const sensor_msgs::PointCloud2ConstPtr &cloud,
+                                                                      sensor_msgs::LaserScan &output,
                                                                       const tf2::Transform &T, const double range_min )
 {
   // Transform borders and target plane to original coordinates (saved resources to not have to transform the whole point cloud)
@@ -308,4 +308,4 @@ void IpaPointCloudToLaserScanNodelet::convert_pointcloud_to_laserscan(const sens
   }
 }
 
-PLUGINLIB_DECLARE_CLASS(ipa_pointcloud_to_laserscan, IpaPointCloudToLaserScanNodelet, pointcloud_to_laserscan::IpaPointCloudToLaserScanNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(pointcloud_to_laserscan::IpaPointCloudToLaserScanNodelet, nodelet::Nodelet);

--- a/src/pointcloud_to_laserscan_nodelet.cpp
+++ b/src/pointcloud_to_laserscan_nodelet.cpp
@@ -238,4 +238,4 @@ namespace pointcloud_to_laserscan
 
 }
 
-PLUGINLIB_DECLARE_CLASS(pointcloud_to_laserscan, PointCloudToLaserScanNodelet, pointcloud_to_laserscan::PointCloudToLaserScanNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(pointcloud_to_laserscan::PointCloudToLaserScanNodelet, nodelet::Nodelet);

--- a/src/roi_outlier_removal_nodelet.cpp
+++ b/src/roi_outlier_removal_nodelet.cpp
@@ -38,7 +38,7 @@
 /*
  * Author: Sofie Nilsson
  */
- 
+
 
 #include <pointcloud_to_laserscan/roi_outlier_removal.h>
 #include <pluginlib/class_list_macros.h>
@@ -118,7 +118,7 @@ void RoiOutlierRemovalNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPtr &c
   // does not do anything if the problem dies not occur -> leave for compatibility
   std::string cloud_frame_id = cloud_msg->header.frame_id;
   if(cloud_frame_id.find_first_of("/") == 0)
-  { 
+  {
     cloud_frame_id.erase(0,1);
   }
 
@@ -178,13 +178,13 @@ void RoiOutlierRemovalNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPtr &c
 
   NODELET_DEBUG_STREAM("Transform and publish finished");
 }
-  
+
 /**
  * Function to find the points within the defined region of interest and add those to the reduced_cloud.
  * The borders given in specified fame is transformed to the pc frame to avoid unnessecaric point transformations.
  * The reduced cloud in in the same frame as the original cloud, no transformation included!
  */
-void RoiOutlierRemovalNodelet::reduce_point_cloud_to_roi(const pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_cloud,  
+void RoiOutlierRemovalNodelet::reduce_point_cloud_to_roi(const pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_cloud,
                                                          pcl::PointCloud<pcl::PointXYZ>::Ptr reduced_pcl_cloud,
                                                          const tf2::Transform &T)
 {
@@ -218,7 +218,7 @@ void RoiOutlierRemovalNodelet::reduce_point_cloud_to_roi(const pcl::PointCloud<p
   std::vector<int> indices;
   pcl::removeNaNFromPointCloud(*pcl_cloud,*pcl_cloud, indices);
   indices.clear();
-    
+
   int n_points = pcl_cloud->size();
 
   // Declare help variables for point selection
@@ -287,4 +287,4 @@ void RoiOutlierRemovalNodelet::reduce_point_cloud_to_roi(const pcl::PointCloud<p
   }
 }
 
-PLUGINLIB_DECLARE_CLASS(roi_outlier_removal, RoiOutlierRemovalNodelet, pointcloud_to_laserscan::RoiOutlierRemovalNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(pointcloud_to_laserscan::RoiOutlierRemovalNodelet, nodelet::Nodelet);


### PR DESCRIPTION
ref ipa320/care-o-bot#52

Should be multidistro (indigo, kinetic, melodic) capable.
PLUGINLIB_DECLARE_CLASS macro was deprecated for more than 8 years and was now finally removed in melodic.